### PR TITLE
Amls 5529 - AuthAction like FE and few extras

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+[Your pull request description here]
+
+## Related / Dependant PRs?
+
+<!--- List any related issues here -->
+
+## How Has This Been Tested?
+
+<!--- Please describe how you tested your changes -->
+
+## Checklist
+
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+
+- [ ] Breaking change (fix or feature that would cause existing functionality to change).
+- [ ] Build passing.
+- [ ] Unit tests have full coverage.
+- [ ] Unit test approach and implementation has been reviewed with QA (testers).
+- [ ] Requires acceptance test run.
+- [ ] Appropriate labels added.
+- [ ] RELEASE NOTES ADDED.

--- a/app/config/Module.scala
+++ b/app/config/Module.scala
@@ -27,9 +27,11 @@ class Module extends AbstractModule {
     bind(classOf[DataRetrievalAction]).to(classOf[DataRetrievalActionImpl]).asEagerSingleton()
     bind(classOf[DataRequiredAction]).to(classOf[DataRequiredActionImpl]).asEagerSingleton()
 
+    //TODO: Below to be removed in the future
     // For session based storage instead of cred based, change to SessionIdentifierAction
     bind(classOf[IdentifierAction]).to(classOf[SessionIdentifierAction]).asEagerSingleton()
 
+    //TODO: to be updated to AMLS FE repository when session based storage removed
     bind(classOf[SessionRepository]).to(classOf[DefaultSessionRepository]).asEagerSingleton()
   }
 }

--- a/app/connectors/AMLSConnector.scala
+++ b/app/connectors/AMLSConnector.scala
@@ -31,7 +31,7 @@ class AMLSConnector @Inject()(config: Configuration,
                              (implicit ec: ExecutionContext) {
 
   private val baseUrl                 = config.get[Service]("microservice.services.amls-frontend")
-  private[connectors] val url: String = s"$baseUrl/amp"
+  private[connectors] val url: String = s"$baseUrl/eab"
 
   def get(id: String)(implicit hc: HeaderCarrier): Future[Option[JsObject]] = {
     val getUrl = s"$url/$id"

--- a/app/connectors/AMLSConnector.scala
+++ b/app/connectors/AMLSConnector.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import config.Service
+import javax.inject.Inject
+import models.UserAnswers
+import play.api.Configuration
+import play.api.libs.json.JsObject
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.bootstrap.http.HttpClient
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class AMLSConnector @Inject()(config: Configuration,
+                              implicit val httpClient: HttpClient)
+                             (implicit ec: ExecutionContext) {
+
+  private val baseUrl                 = config.get[Service]("microservice.services.amls-frontend")
+  private[connectors] val url: String = s"$baseUrl/amp"
+
+  def get(id: String)(implicit hc: HeaderCarrier): Future[Option[JsObject]] = {
+    val getUrl = s"$url/$id"
+    httpClient.GET[Option[JsObject]](getUrl)
+  }
+
+  def set(id: String, userAnswers: UserAnswers)(implicit hc: HeaderCarrier): Future[UserAnswers] = {
+    val putUrl = s"$url/$id"
+    httpClient.PUT[UserAnswers, UserAnswers](putUrl, userAnswers)
+  }
+
+}

--- a/app/controllers/actions/IdentifierAction.scala
+++ b/app/controllers/actions/IdentifierAction.scala
@@ -31,6 +31,8 @@ import uk.gov.hmrc.play.HeaderCarrierConverter
 
 import scala.concurrent.{ExecutionContext, Future}
 
+//TODO: Below need to be updated to have same structure like in AMP when connecting to AMLS FE
+
 trait IdentifierAction extends ActionBuilder[IdentifierRequest, AnyContent]
 
 final case class enrolmentNotFound(msg: String = "enrolmentNotFound") extends AuthorisationException(msg)
@@ -92,6 +94,8 @@ class AuthenticatedIdentifierAction @Inject()(
     }
   }
 }
+
+//TODO: Below need to be removed when connecting to AMLS FE
 
 class SessionIdentifierAction @Inject()(config: FrontendAppConfig,
                                         val parser: BodyParsers.Default)

--- a/app/models/UserAnswers.scala
+++ b/app/models/UserAnswers.scala
@@ -23,6 +23,8 @@ import play.api.libs.json._
 
 import scala.util.{Failure, Success, Try}
 
+//TODO: This to be updated to version as in AMP when connecting to AMLS FE
+
 final case class UserAnswers(
                               id: String,
                               data: JsObject = Json.obj(),

--- a/app/models/requests/IdentifierRequest.scala
+++ b/app/models/requests/IdentifierRequest.scala
@@ -17,5 +17,6 @@
 package models.requests
 
 import play.api.mvc.{Request, WrappedRequest}
+import uk.gov.hmrc.auth.core.AffinityGroup
 
-case class IdentifierRequest[A] (request: Request[A], identifier: String) extends WrappedRequest[A](request)
+case class IdentifierRequest[A] (request: Request[A], identifier: String, affinityGroup: Option[AffinityGroup] = None) extends WrappedRequest[A](request)

--- a/app/models/requests/IdentifierRequest.scala
+++ b/app/models/requests/IdentifierRequest.scala
@@ -19,4 +19,5 @@ package models.requests
 import play.api.mvc.{Request, WrappedRequest}
 import uk.gov.hmrc.auth.core.AffinityGroup
 
+//TODO: This to be updated to version in AMP when connecting to AMLS FE
 case class IdentifierRequest[A] (request: Request[A], identifier: String, affinityGroup: Option[AffinityGroup] = None) extends WrappedRequest[A](request)

--- a/app/repositories/AMLSFrontEndSessionRepository.scala
+++ b/app/repositories/AMLSFrontEndSessionRepository.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories
+
+import akka.stream.Materializer
+import connectors.AMLSConnector
+import javax.inject.Inject
+import models.UserAnswers
+import play.api.Configuration
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class DefaultAMLSFrontEndSessionRepository @Inject()(amlsConnector: AMLSConnector,
+                                                     config: Configuration)
+                                                    (implicit ec: ExecutionContext, m: Materializer) extends AMLSFrontEndSessionRepository {
+
+  def get(id: String)(implicit hc: HeaderCarrier): Future[Option[UserAnswers]] =
+    amlsConnector.get(id).map {
+      _.map {
+        json =>
+          json.as[UserAnswers]
+      }
+    } recover {
+      case _: Exception => throw new Exception("Failed")
+    }
+
+  def set(userAnswers: UserAnswers)(implicit hc: HeaderCarrier): Future[Boolean] =
+    amlsConnector.set(userAnswers.id, userAnswers).map { r =>
+      r.isInstanceOf[UserAnswers]
+    } recover {
+      case e: Exception => throw new Exception(e.getMessage)
+    }
+}
+
+trait AMLSFrontEndSessionRepository {
+
+  def get(id: String)(implicit hc: HeaderCarrier): Future[Option[UserAnswers]]
+
+  def set(userAnswers: UserAnswers)(implicit hc: HeaderCarrier): Future[Boolean]
+}

--- a/generate-my-release-note.sh
+++ b/generate-my-release-note.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "Please enter the Jira reference and a description. I.e. AMLS-0001 'My ticket description'"
+read ref desc
+
+mkdir -p "release_notes/"
+echo "Generating release note for [$ref] - $desc"
+echo " + [$ref] - $desc" > "release_notes/$ref.txt"

--- a/generate-release-notes.sh
+++ b/generate-release-notes.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+echo "Please enter the tag. I.e. v0.0.1:"
+read tag
+
+mkdir -p "release_notes/releases/$tag"
+echo "Generating release notes for $tag"
+
+cat release_notes/*.txt > release_notes/releases/$tag/"$tag-$(date +'%d-%m-%Y')".txt
+rm -rf release_notes/*.txt

--- a/release_notes/AMLS-5529.txt
+++ b/release_notes/AMLS-5529.txt
@@ -1,0 +1,1 @@
+ + [AMLS-5529] - 'Added auth action like in AMP, added AMLSFrontendRepository and AmlsConnector'

--- a/test/connectors/AMLSConnectorSpec.scala
+++ b/test/connectors/AMLSConnectorSpec.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import java.time.{LocalDate, LocalDateTime, ZoneOffset}
+
+import base.SpecBase
+import models.EabServicesProvided.Auctioneering
+import models.UserAnswers
+import org.mockito.Matchers.{any, eq => eqTo}
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.EabServicesProvidedPage
+import play.api.Configuration
+import play.api.libs.json.{JsObject, Json}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.bootstrap.http.HttpClient
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class AMLSConnectorSpec extends SpecBase with MockitoSugar {
+
+  implicit val hc   = HeaderCarrier()
+  val amlsConnector = new AMLSConnector(config = mock[Configuration], httpClient = mock[HttpClient])
+  val dateVal       = LocalDateTime.now
+  val answers       = UserAnswers("id").set(EabServicesProvidedPage,  Seq(Auctioneering)).success.value
+
+  val completeData  = Json.obj(
+    "typeOfParticipant"            -> Seq("artGalleryOwner"),
+    "boughtOrSoldOverThreshold"    -> true,
+    "dateTransactionOverThreshold" -> LocalDate.now,
+    "identifyLinkedTransactions"   -> true,
+    "percentageExpectedTurnover"   -> "fortyOneToSixty"
+  )
+
+  val completeJson  = Json.obj(
+    "_id"         -> "someid",
+    "data"        -> completeData,
+    "lastUpdated" -> Json.obj("$date" -> dateVal.atZone(ZoneOffset.UTC).toInstant.toEpochMilli)
+  )
+
+  "GET" must {
+    "successfully fetch cache" in {
+      val getUrl = s"${amlsConnector.url}/someid"
+
+      when {
+        amlsConnector.httpClient.GET[Option[JsObject]](eqTo(getUrl))(any(), any(), any())
+      } thenReturn Future.successful(Some(completeJson))
+
+      whenReady(amlsConnector.get("someid")) {
+        _ mustBe Some(completeJson)
+      }
+    }
+  }
+
+  "POST" must {
+    "successfully write cache" in {
+      val putUrl = s"${amlsConnector.url}/someid"
+
+      when {
+        amlsConnector.httpClient.PUT[UserAnswers, UserAnswers](eqTo(putUrl), eqTo(answers), any())(any(), any(), any(), any())
+      } thenReturn Future.successful(answers)
+
+      whenReady(amlsConnector.set("someid", answers)) {
+        _ mustBe answers
+      }
+    }
+  }
+}

--- a/test/connectors/AMLSConnectorSpec.scala
+++ b/test/connectors/AMLSConnectorSpec.scala
@@ -41,11 +41,11 @@ class AMLSConnectorSpec extends SpecBase with MockitoSugar {
   val answers       = UserAnswers("id").set(EabServicesProvidedPage,  Seq(Auctioneering)).success.value
 
   val completeData  = Json.obj(
-    "typeOfParticipant"            -> Seq("artGalleryOwner"),
-    "boughtOrSoldOverThreshold"    -> true,
-    "dateTransactionOverThreshold" -> LocalDate.now,
-    "identifyLinkedTransactions"   -> true,
-    "percentageExpectedTurnover"   -> "fortyOneToSixty"
+    "eabServicesProvided"            -> Seq("businessTransfer"),
+    "redressScheme"    -> "other",
+    "redressSchemeDetail" -> "other redress scheme",
+    "penalisedEstateAgentsAct"   -> false,
+    "penalisedProfessionalBody"   -> false
   )
 
   val completeJson  = Json.obj(

--- a/test/controllers/actions/AuthActionSpec.scala
+++ b/test/controllers/actions/AuthActionSpec.scala
@@ -18,6 +18,7 @@ package controllers.actions
 
 import base.SpecBase
 import com.google.inject.Inject
+import controllers.actions.AuthActionSpec.{agentCtAuthRetrievals, agentSaAuthRetrievals, emptyAuthRetrievals, fakeAuthConnector, orgAuthRetrievals}
 import controllers.routes
 import play.api.mvc.{BodyParsers, Results}
 import play.api.test.Helpers._
@@ -160,6 +161,103 @@ class AuthActionSpec extends SpecBase {
         status(result) mustBe SEE_OTHER
 
         redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad().url)
+      }
+    }
+
+    "AffinityGroup is Organisation" when {
+      "the user has valid credentials" must {
+        "return successful result" in {
+          val application = applicationBuilder(userAnswers = None).build()
+
+          val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
+
+          val authAction = new AuthenticatedIdentifierAction(fakeAuthConnector(orgAuthRetrievals), frontendAppConfig, bodyParsers)
+          val controller = new Harness(authAction)
+          val result = controller.onPageLoad()(fakeRequest)
+
+          status(result) mustBe OK
+        }
+      }
+    }
+
+    "AffinityGroup is not Organisation" when {
+      "the user has valid credentials for sa" must {
+        "return successful result" in {
+          val application = applicationBuilder(userAnswers = None).build()
+
+          val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
+
+          val authAction = new AuthenticatedIdentifierAction(fakeAuthConnector(agentSaAuthRetrievals), frontendAppConfig, bodyParsers)
+          val controller = new Harness(authAction)
+          val result = controller.onPageLoad()(fakeRequest)
+
+          status(result) mustBe OK
+        }
+      }
+
+      "the user has valid credentials for ct" must {
+        "return successful result" in {
+          val application = applicationBuilder(userAnswers = None).build()
+
+          val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
+
+          val authAction = new AuthenticatedIdentifierAction(fakeAuthConnector(agentCtAuthRetrievals), frontendAppConfig, bodyParsers)
+          val controller = new Harness(authAction)
+          val result = controller.onPageLoad()(fakeRequest)
+
+          status(result) mustBe OK
+        }
+      }
+
+      "there is no match in retrievals" must {
+        "redirect to login" in {
+          val application = applicationBuilder(userAnswers = None).build()
+
+          val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
+
+          val authAction = new AuthenticatedIdentifierAction(fakeAuthConnector(emptyAuthRetrievals), frontendAppConfig, bodyParsers)
+          val controller = new Harness(authAction)
+          val result = controller.onPageLoad()(fakeRequest)
+
+          status(result) mustBe SEE_OTHER
+
+          redirectLocation(result).get must startWith(frontendAppConfig.loginUrl)
+        }
+      }
+
+      "there is no enrolments" must {
+        "redirect to unauthorised page" in {
+          val application = applicationBuilder(userAnswers = None).build()
+
+          val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
+
+          val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new enrolmentNotFound), frontendAppConfig, bodyParsers)
+          val controller = new Harness(authAction)
+          val result = controller.onPageLoad()(fakeRequest)
+
+          status(result) mustBe SEE_OTHER
+
+          redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad().url)
+        }
+      }
+
+      "any other exception thrown" must {
+        "redirect to unauthorised page" in {
+
+          final case class OtherException(msg: String = "otherException") extends AuthorisationException(msg)
+
+          val application = applicationBuilder(userAnswers = None).build()
+
+          val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
+
+          val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new OtherException()), frontendAppConfig, bodyParsers)
+          val controller = new Harness(authAction)
+          val result = controller.onPageLoad()(fakeRequest)
+
+          status(result) mustBe SEE_OTHER
+
+          redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad().url)
+        }
       }
     }
   }


### PR DESCRIPTION
In this PR added AuthAction like in Frontend, AMLSConnector, AMLSFESessionRepository, release note generator and PR template.

!!! IMPORTANT !!! 
EAB micro-service is not connecting to AMLS FE repository, therefore it is not using AuthAction for authorisation but it's using session based solution. Auth implementation needs to be updated in the future to the similar one like in AMP, UserAnswers need to be updated too, removed SessionBased repository references and AMLSFERepository switched on instead. Also binding needs to be updated in configuration.